### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/tag-and-publish.yaml
+++ b/.github/workflows/tag-and-publish.yaml
@@ -26,7 +26,7 @@ jobs:
         run: echo ${{ steps.tag_version.outputs.new_tag}}
       - 
         name: Publish to Registry
-        uses: elgohr/Publish-Docker-Github-Action@master
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: tomso/az-pipeline-container
           username: ${{ secrets.DOCKER_USERNAME }}


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore